### PR TITLE
Ignore method param 0 (fixes #1)

### DIFF
--- a/meta_sig_parser.cpp
+++ b/meta_sig_parser.cpp
@@ -26,14 +26,19 @@ std::wstring meta_sig_parser::parse_property(wchar_t* name)
 	return parse_element_type() + L" " + std::wstring(name);
 }
 
-std::wstring meta_sig_parser::parse_method(const wchar_t* name, const std::vector<std::wstring>& param_names, bool omit_return_type)
+std::wstring meta_sig_parser::parse_method(const wchar_t* name, const std::vector<std::wstring>& raw_param_names, bool omit_return_type)
 {
 	std::wstring ret = name;
-
+	std::vector<std::wstring> param_names = raw_param_names;
 	CorCallingConvention calling_conv = (CorCallingConvention) uncompress_data(); // calling convention
 	ULONG param_count = uncompress_data();
 
 	std::wstring return_type = parse_element_type();
+	if (return_type != L"void")
+	{
+	    param_names.erase(param_names.begin());
+	}
+
 	if (!omit_return_type) ret = return_type  + L" " + ret;
 
 	if (param_count != 0) {


### PR DESCRIPTION
A quick hack to remove parameter 0 from the method parameter name list (fixes #1). (In cases where a method's signature indicates a `void` return type, parameter 0 isn't present.)

[ECMA-335 (II.15.4.1.4)](https://www.ecma-international.org/publications/files/ECMA-ST/ECMA-335.pdf) has more details on the `.param` directive:
```
Unlike CIL instructions, .param uses index 0 to specify the return value of the method,
index 1 to specify the first parameter of the method, index 2 to specify the second parameter of the
method, and so on.

[Note: The CLI attaches no semantic whatsoever to these values—it is entirely up to compilers to
implement any semantic they wish (e.g., so-called default argument values). end note] 
```