### PR TITLE
Ensure params vector isn't empty before calling erase

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,6 @@
+# 0.2 (2018.05.03)
+* Fixed an issue with incorrectly emitted parameters (#1)
+
 # 0.1 (2013.05.18)
 * Comparing: types, fields, properties, events, methods
 * NOT SUPPORTED YET: attributes, virtual methods, nested types, interfaces implemented by types

--- a/meta_sig_parser.cpp
+++ b/meta_sig_parser.cpp
@@ -34,7 +34,7 @@ std::wstring meta_sig_parser::parse_method(const wchar_t* name, const std::vecto
 	ULONG param_count = uncompress_data();
 
 	std::wstring return_type = parse_element_type();
-	if (return_type != L"void")
+	if (return_type != L"void" && param_names.size() > 0)
 	{
 	    param_names.erase(param_names.begin());
 	}

--- a/metadiff.cpp
+++ b/metadiff.cpp
@@ -143,7 +143,7 @@ int _tmain(int argc, _TCHAR* argv[])
 	const wchar_t* err_arg = nullptr;
 	wstring new_files_pattern, old_files_pattern, type_filter;
 
-	printf_s("\n MetaDiff v0.1 https://github.com/WalkingCat/MetaDiff\n\n");
+	printf_s("\n MetaDiff v0.2 https://github.com/WalkingCat/MetaDiff\n\n");
 
 	for(int i = 1; i < argc; ++i) {
 		const wchar_t* arg = argv[i];


### PR DESCRIPTION
Missed a case in PR #2, this resolves crashing when attempting to diff 17655 => 17661